### PR TITLE
fix bad content-type in captcha response

### DIFF
--- a/lib/server/routes.js
+++ b/lib/server/routes.js
@@ -39,7 +39,7 @@ function _verifyCaptchaMiddleware(params, req, res) {
 };
 
 Sikka.routes._sendCaptchPage = function _sendCaptchPage(req, res) {
-  res.writeHead(200, {'Content-Type': 'html'});
+  res.writeHead(200, {'Content-Type': 'text/html'});
   var tmplValues = {
     captchaSiteKey: Config.captcha.siteKey,
     redirectUrl: req.url


### PR DESCRIPTION
In some undiscovered cases, the content-type of the captcha-page will be text/plain instead of text/html.
a blank new meteor-project with sikka doesn't send the captcha-page in text/html, but unfortunately my more complex meteor-app does. I don't know why, but the response content-type in line 42 seems to be wrong. It should be 'text/html' not 'html'. Changing this fixed the problem for me.
